### PR TITLE
Fix building the jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,10 @@ minecraft {
 }
 
 repositories {
-//	maven {
-//		name = "Onyx Studios"
-//		url = "https://maven.onyxstudios.dev"
-//	}
+	maven {
+		name = "Onyx Studios"
+		url = "https://maven.onyxstudios.dev"
+	}
 	maven {
 		url 'https://maven.fabricmc.net/io/github/prospector/modmenu/'
 	}
@@ -34,23 +34,24 @@ dependencies {
 	//to change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modCompile "net.fabricmc:fabric-loader:${project.loader_version}"
+	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modCompile "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	modImplementation ("net.fabricmc.fabric-api:fabric-api:${project.fabric_version}") {
+		force = true //Force the version we want rather than trusting Gradle to pick it over transitive suggestions
+	}
 
-	//modCompile "com.github.NerdHubMC:Cardinal-Components-API:${project.cardinal_version}"
-	modImplementation "com.github.NerdHubMC:Cardinal-Components-API:${project.cardinal_version}"
-	include "com.github.NerdHubMC:Cardinal-Components-API:${project.cardinal_version}"
+	include modApi ("com.github.NerdHubMC.Cardinal-Components-API:cardinal-components-base:${project.cardinal_version}")
+	include modApi ("com.github.NerdHubMC.Cardinal-Components-API:cardinal-components-entity:${project.cardinal_version}")
 
-	modImplementation "io.github.prospector:modmenu:${project.mod_menu_version}";
-	//include "io.github.prospector:modmenu:${project.mod_menu_version}";
+	modImplementation ("io.github.prospector:modmenu:${project.mod_menu_version}")
 
-	modImplementation ("io.github.cottonmc:Cotton:${project.cotton_version}") { exclude(group: "io.github.prospector.modmenu", module: "ModMenu") exclude(group: "io.github.cottonmc", module: "Jankson")}
-	//include "io.github.cottonmc.cotton:Cotton:${project.cotton_version}"
+	modImplementation ("io.github.cottonmc:Cotton:${project.cotton_version}") {
+		exclude(group: "io.github.prospector.modmenu", module: "ModMenu")
+		exclude(group: "io.github.cottonmc", module: "Jankson")
+	}
 
-	modImplementation "io.github.alloffabric:BeeProductive:${project.beeproductive_version}";
-	//include "io.github.alloffabric:BeeProductive:${project.beeproductive_version}";
+	modImplementation ("io.github.alloffabric:BeeProductive:${project.beeproductive_version}")
 }
 
 processResources {


### PR DESCRIPTION
Switches to using the individual parts of Cardinal Components so they can be downloaded straight from Onyx's maven. Suspect in the past it was downloading an older version which happened to match the version from Jitpack. Avoids including more of it than necessary into the jar too.

Also forces the project's Fabric API version which avoids any dependency having a say on which version is used. Gradle doesn't always pick the right version and so can hide other problems (like what you found).
If you run `gradlew dependencies` you can see how many it has to pick from:
<details><summary>In here</summary>
<p>

```
modImplementation
+--- net.fabricmc:fabric-loader:0.7.8+build.184
+--- net.fabricmc.fabric-api:fabric-api:0.4.32+build.292-1.15
|    +--- net.fabricmc.fabric-api:fabric-api-base:0.1.2+b7f9825d0c -> 0.1.2+b7f9825de4
|    |    \--- net.fabricmc:fabric-loader:0.7.1+build.173 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-biomes-v1:0.1.5+3b05f68e0c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-blockrenderlayer-v1:1.1.4+c6a8ea890c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-commands-v0:0.1.2+b7f9825d0c -> 0.1.2+b7f9825de4
|    |    \--- net.fabricmc:fabric-loader:0.7.1+build.173 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-containers-v0:0.1.3+b7f9825d0c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-content-registries-v0:0.1.3+b7f9825d0c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-crash-report-info-v1:0.1.2+b7f9825d0c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-dimensions-v1:0.2.4+203491ea0c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-events-interaction-v0:0.2.7+a1bd31180c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-events-lifecycle-v0:0.1.2+b7f9825d0c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-item-groups-v0:0.1.6+ec40b2e10c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-keybindings-v0:0.1.1+dfdb52d60c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-loot-tables-v1:0.1.5+e08a73050c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-mining-levels-v0:0.1.1+b7f9825d0c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-models-v0:0.1.0+dfdb52d60c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-networking-blockentity-v0:0.2.3+e08a73050c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-networking-v0:0.1.7+12515ed90c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-object-builders-v0:0.1.3+e4c9a9c30c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-particles-v1:0.1.1+dfdb52d60c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-registry-sync-v0:0.2.6+f3d8141b0c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-renderer-api-v1:0.2.10+f08b61330c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-renderer-indigo:0.2.23+9290e2ed0c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-renderer-registries-v1:2.0.1+5a0f9a600c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-rendering-data-attachment-v1:0.1.3+b7f9825d0c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-rendering-fluids-v1:0.1.6+12515ed90c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-rendering-v0:1.1.0+534104900c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-rendering-v1:0.1.0+534104900c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-resource-loader-v0:0.1.10+06c939b30c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-tag-extensions-v0:0.1.3+abd915800c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- net.fabricmc.fabric-api:fabric-textures-v0:1.0.4+821cdba70c
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
+--- io.github.prospector:modmenu:1.10.0
|    +--- net.fabricmc:fabric-loader:0.7.5+build.178 -> 0.7.8+build.184
|    \--- net.fabricmc.fabric-api:fabric-api:0.4.29+build.290-1.15 -> 0.4.32+build.292-1.15 (*)
+--- io.github.cottonmc:Cotton:1.0.2
|    +--- io.github.cottonmc.cotton:cotton-player-events:+ -> 1.0.2
|    |    +--- net.fabricmc:fabric-loader:0.7.8+build.184
|    |    \--- net.fabricmc.fabric-api:fabric-api-base:0.1.2+b7f9825de4 (*)
|    +--- io.github.cottonmc.cotton:cotton-logging:+ -> 1.0.0-rc.4
|    |    \--- net.fabricmc:fabric-loader:0.7.8+build.184
|    +--- io.github.cottonmc.cotton:cotton-config:+ -> 1.0.0-rc.4
|    |    +--- io.github.cottonmc:Jankson-Fabric:2.0.0+j1.2.0 -> 2.0.1+j1.2.0
|    |    |    \--- net.fabricmc:fabric-loader:0.6.2+build.166 -> 0.7.8+build.184
|    |    +--- io.github.cottonmc.cotton:cotton-logging:1.0.0-rc.4 (*)
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    +--- io.github.cottonmc.cotton:cotton-datapack:+ -> 1.0.0-rc.4
|    |    +--- io.github.cottonmc.cotton:cotton-config:1.0.0-rc.4 (*)
|    |    +--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
|    |    \--- net.fabricmc.fabric-api:fabric-commands-v0:0.1.2+b7f9825de4 (*)
|    +--- io.github.cottonmc.cotton:cotton-commons:+ -> 1.0.0-rc.4
|    |    +--- io.github.cottonmc.cotton:cotton-datapack:1.0.0-rc.4 (*)
|    |    +--- net.fabricmc:fabric-loader:0.7.8+build.184
|    |    +--- net.fabricmc.fabric-api:fabric-item-groups-v0:0.1.4+b7f9825de4 -> 0.1.6+ec40b2e10c (*)
|    |    \--- net.fabricmc.fabric-api:fabric-tag-extensions-v0:0.1.2+b7f9825de4 -> 0.1.3+abd915800c (*)
|    +--- io.github.cottonmc.cotton:cotton-cauldron:+ -> 1.0.0-rc.6
|    |    +--- io.github.cottonmc:LibCD:2.2.2+1.15.2
|    |    |    +--- io.github.cottonmc:Jankson-Fabric:2.0.1+j1.2.0 (*)
|    |    |    +--- net.fabricmc:fabric-loader:0.7.2+build.175 -> 0.7.8+build.184
|    |    |    \--- net.fabricmc.fabric-api:fabric-api:0.4.25+build.282-1.15 -> 0.4.32+build.292-1.15 (*)
|    |    +--- io.github.cottonmc.cotton:cotton-commons:1.0.0-rc.4 (*)
|    |    \--- net.fabricmc:fabric-loader:0.7.8+build.184
|    +--- io.github.cottonmc:LibCD:1.3.1+1.14.4 -> 2.2.2+1.15.2 (*)
|    +--- net.fabricmc:fabric-loader:0.4.8+build.157 -> 0.7.8+build.184
|    \--- net.fabricmc.fabric-api:fabric-api:0.3.0+build.200 -> 0.4.32+build.292-1.15 (*)
\--- io.github.alloffabric:BeeProductive:1.0.2+1.15.1
     +--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.8+build.184
     +--- net.fabricmc.fabric-api:fabric-api:0.4.24+build.279-1.15 -> 0.4.32+build.292-1.15 (*)
     +--- com.github.NerdHubMC.Cardinal-Components-API:cardinal-components-base:2.1.0
     |    +--- net.fabricmc:fabric-loader:0.6.1+build.165 -> 0.7.8+build.184
     |    +--- net.fabricmc.fabric-api:fabric-api-base:0.1.0+59147463 -> 0.1.2+b7f9825de4 (*)
     |    \--- net.fabricmc.fabric-api:fabric-networking-v0:0.1.2+200eb5c2 -> 0.1.7+12515ed90c (*)
     +--- com.github.NerdHubMC.Cardinal-Components-API:cardinal-components-entity:2.1.0
     |    +--- net.fabricmc:fabric-loader:0.6.1+build.165 -> 0.7.8+build.184
     |    +--- net.fabricmc.fabric-api:fabric-api-base:0.1.0+59147463 -> 0.1.2+b7f9825de4 (*)
     |    \--- net.fabricmc.fabric-api:fabric-networking-v0:0.1.2+200eb5c2 -> 0.1.7+12515ed90c (*)
     \--- io.github.cottonmc:BeeCompatible:2.0.0+1.15.1
          +--- net.fabricmc:fabric-loader:0.7.2+build.175 -> 0.7.8+build.184
          \--- net.fabricmc.fabric-api:fabric-api:0.4.24+build.279-1.15 -> 0.4.32+build.292-1.15 (*)

modApi
+--- com.github.NerdHubMC.Cardinal-Components-API:cardinal-components-base:2.3.0
|    +--- net.fabricmc:fabric-loader:0.7.6+build.179
|    +--- net.fabricmc.fabric-api:fabric-api-base:0.1.2+b7f9825d95
|    |    \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.6+build.179
|    \--- net.fabricmc.fabric-api:fabric-networking-v0:0.1.7+12515ed995
|         \--- net.fabricmc:fabric-loader:0.7.2+build.174 -> 0.7.6+build.179
\--- com.github.NerdHubMC.Cardinal-Components-API:cardinal-components-entity:2.3.0
     +--- net.fabricmc:fabric-loader:0.7.6+build.179
     +--- net.fabricmc.fabric-api:fabric-api-base:0.1.2+b7f9825d95 (*)
     \--- net.fabricmc.fabric-api:fabric-networking-v0:0.1.7+12515ed995 (*)
```
</p>
</details>

You can test it [build from Jitpack](https://jitpack.io/com/github/Chocohead/Bumblezone-Fabric/patch-1-34dab31524-1/build.log): [here](https://jitpack.io/com/github/Chocohead/Bumblezone-Fabric/patch-1-34dab31524-1/Bumblezone-Fabric-patch-1-34dab31524-1.jar).