### PR TITLE
Update to Cardinal Components API V3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,6 @@ org.gradle.jvmargs = -Xmx2G
 	fabric_version=0.20.2+build.402-1.16
  	auto_config_version = 3.2.2
 	cloth_config_version = 4.8.1
-	cardinal_version = 2.6.0
+	cardinal_version = 2.7.1
 	mod_menu_version = 1.14.6+build.31
 	# beeproductive_version = 1.0.2+1.15.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/telepathicgrunt/bumblezone/entities/IPlayerComponent.java
+++ b/src/main/java/net/telepathicgrunt/bumblezone/entities/IPlayerComponent.java
@@ -1,6 +1,6 @@
 package net.telepathicgrunt.bumblezone.entities;
 
-import nerdhub.cardinal.components.api.component.Component;
+import dev.onyxstudios.cca.api.v3.component.Component;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Vec3d;
 

--- a/src/main/java/net/telepathicgrunt/bumblezone/entities/PlayerComponent.java
+++ b/src/main/java/net/telepathicgrunt/bumblezone/entities/PlayerComponent.java
@@ -51,17 +51,15 @@ public class PlayerComponent implements IPlayerComponent {
 
 
     @Override
-    public void fromTag(CompoundTag tag) {
+    public void readFromNbt(CompoundTag tag) {
         this.teleporting = tag.getBoolean("teleporting");
         this.nonBZDimensionType = new Identifier(tag.getString("non_bz_dimensiontype_namespace"), tag.getString("non_bz_dmensiontype_path"));
     }
     @Override
-    public CompoundTag toTag(CompoundTag tag) {
+    public void writeToNbt(CompoundTag tag) {
         tag.putBoolean("teleporting", this.teleporting);
         tag.putString("non_bz_dimensiontype_namespace", nonBZDimensionType.getNamespace());
         tag.putString("non_bz_dmensiontype_path", nonBZDimensionType.getPath());
-
-        return tag;
     }
 
 }

--- a/src/main/java/net/telepathicgrunt/bumblezone/generation/BzChunkGenerator.java
+++ b/src/main/java/net/telepathicgrunt/bumblezone/generation/BzChunkGenerator.java
@@ -5,7 +5,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectList;
 import it.unimi.dsi.fastutil.objects.ObjectListIterator;
-import jdk.internal.jline.internal.Nullable;
+import me.sargunvohra.mcmods.autoconfig1u.shadowed.blue.endless.jankson.annotation.Nullable;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.block.BlockState;
@@ -39,7 +39,9 @@ import net.minecraft.world.chunk.ChunkSection;
 import net.minecraft.world.chunk.ProtoChunk;
 import net.minecraft.world.gen.ChunkRandom;
 import net.minecraft.world.gen.StructureAccessor;
-import net.minecraft.world.gen.chunk.*;
+import net.minecraft.world.gen.chunk.ChunkGenerator;
+import net.minecraft.world.gen.chunk.StructuresConfig;
+import net.minecraft.world.gen.chunk.VerticalBlockSample;
 import net.minecraft.world.gen.feature.StructureFeature;
 import net.telepathicgrunt.bumblezone.Bumblezone;
 import net.telepathicgrunt.bumblezone.blocks.BzBlocks;
@@ -51,7 +53,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,11 +27,19 @@
     ],
     "client": [
       "net.telepathicgrunt.bumblezone.client.BumblezoneClient"
+    ],
+    "cardinal-components-entity": [
+      "net.telepathicgrunt.bumblezone.Bumblezone"
     ]
   },
   "mixins": [
     "the_bumblezone.mixins.json"
   ],
+  "custom": {
+    "cardinal-components": [
+      "the_bumblezone:player_component"
+    ]
+  },
 
   "accessWidener" : "the_bumblezone.accesswidener",
 


### PR DESCRIPTION
With CCA V2 interfaces getting removed in 1.17, now is a fairly good time to switch to V3. In the case of Bumblezone, it's a fairly simple update but hey, less work for you.